### PR TITLE
Allow Custom Host Server Ports

### DIFF
--- a/src/raknet.rs
+++ b/src/raknet.rs
@@ -72,8 +72,14 @@ fn connect(this: usize, host: *const c_char, port: u16, _password: *const c_char
 		drop(b);
 		set_conn(this, MTU);
 	}
-	let host = unsafe { CStr::from_ptr(host).to_str().unwrap() };
-	let port = if port == 1001 { 21836 } else { port };
+	let mut host = unsafe { CStr::from_ptr(host).to_str().unwrap() };
+	let mut host_port = 21836;
+	if host.find(':') != None {
+		let split_host_name: Vec<&str> = host.split(':').collect();
+		host = split_host_name[0];
+		host_port = split_host_name[1].parse::<u16>().unwrap();
+	}
+	let port = if port == 1001 { host_port } else { port };
 	let mut conn = Box::new(Connection::new(host, port)?);
 	conn.send(b"\x043.25 ND1", REL_ORD)?;
 	set_conn(this, Box::into_raw(conn));

--- a/src/raknet.rs
+++ b/src/raknet.rs
@@ -74,10 +74,10 @@ fn connect(this: usize, host: *const c_char, port: u16, _password: *const c_char
 	}
 	let mut host = unsafe { CStr::from_ptr(host).to_str().unwrap() };
 	let mut host_port = 21836;
-	if host.find(':') != None {
-		let split_host_name: Vec<&str> = host.split(':').collect();
-		host = split_host_name[0];
-		host_port = split_host_name[1].parse::<u16>().unwrap();
+	if let Some(index) = host.find(":") {
+		let (h, p) = host.split_at(index);
+		host = h;
+		host_port = p[1..].parse().unwrap();
 	}
 	let port = if port == 1001 { host_port } else { port };
 	let mut conn = Box::new(Connection::new(host, port)?);


### PR DESCRIPTION
Currently, there is a requirement for the authorization server to use port 21836, no matter what host is used. This prevents the option of changing the server port on the host's end, such as allowing multiple Lego Universe servers to run on a single operating system. This change adds a check to the host string to see if a custom port is specified, and replace 21836 with the specified port. If no port is given, it defaults to the old behavior of using port 21836.

This was tested with a stock version of Uchu and a modified version to use port 20000, with localhost and localhost:20000 being used respectively. Both were able to log in, select a character, and load Avant Gardens as expected.